### PR TITLE
Add optional database sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "body-parser": "^1.15.0",
+    "connect-pg-simple": "^3.1.0",
     "csurf": "^1.8.3",
     "express": "^4.13.4",
     "express-enforces-ssl": "^1.1.0",


### PR DESCRIPTION
Heroku discards the file system more often than expected, so we need to use database sessions if a database is available.
